### PR TITLE
Add CI on pull requests

### DIFF
--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -12,6 +12,9 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+  # run on PR to test contributions
+  pull_request:
+
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
   contents: read
@@ -66,11 +69,12 @@ jobs:
         with:
           path: |
             .next/cache
-          # Generate a new cache whenever packages or source files change.
-          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json', '**/yarn.lock') }}-${{ hashFiles('**.[jt]s', '**.[jt]sx') }}
+          # Generate a new cache whenever packages or source files change. Use a separate cache for each branch to prevent a attack of cache pollution
+          # see https://scribesecurity.com/blog/github-cache-poisoning/
+          key: ${{ runner.os }}-${{ github.ref }}-nextjs-${{ hashFiles('**/package-lock.json', '**/yarn.lock') }}-${{ hashFiles('**.[jt]s', '**.[jt]sx') }}
           # If source files changed but packages didn't, rebuild from a prior cache.
           restore-keys: |
-            ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json', '**/yarn.lock') }}-
+            ${{ runner.os }}-${{ github.ref }}-nextjs-${{ hashFiles('**/package-lock.json', '**/yarn.lock') }}-
       - name: Install dependencies
         run: ${{ steps.detect-package-manager.outputs.manager }} ${{ steps.detect-package-manager.outputs.command }}
       - name: Build with Next.js


### PR DESCRIPTION
Make sure the cache is not shared and can't be polluted, see https://scribesecurity.com/blog/github-cache-poisoning/

As the biggest risk is changing the cache used to deploy the website, making sure there is a partition by ref should be enough, as the variable is the complete branch, see https://docs.github.com/en/actions/learn-github-actions/contexts#github-context