### PR TITLE
Fix some a11y issues

### DIFF
--- a/src/components/HowItWorks/Slideshow.tsx
+++ b/src/components/HowItWorks/Slideshow.tsx
@@ -165,7 +165,7 @@ const Slideshow: FC<SlideshowProps> = () => {
           <div className={styles.slideshow__slides}>
             <div className={styles.cardWrapper}>
               {steps.map((d, i) => (
-                <div
+                <button
                   key={`howitworks_${i}`}
                   className={classNames(styles.stepWrapper, styles.column, {
                     [styles.active]: currentSlide === i,
@@ -186,7 +186,7 @@ const Slideshow: FC<SlideshowProps> = () => {
                     <div className={styles.order}>{Number(i) + 1}</div>
                     <div className={styles.description}>{d.description}</div>
                   </div>
-                </div>
+                </button>
               ))}
             </div>
           </div>

--- a/src/components/Leadspace/Leadspace.module.scss
+++ b/src/components/Leadspace/Leadspace.module.scss
@@ -29,13 +29,12 @@
     }
 
     .action {
-      margin-top: 32px;
+      margin-top: 16px;
       padding-left: 16px;
       width: 100%;
       min-width: 20rem;
-      margin-top: 16px;
 
-      label {
+      span {
         flex: 1;
       }
 

--- a/src/components/Leadspace/Leadspace.tsx
+++ b/src/components/Leadspace/Leadspace.tsx
@@ -1,4 +1,3 @@
-import { FC } from 'react';
 import { Column, Button, Grid } from '@carbon/react';
 import { ArrowRight } from '@carbon/icons-react';
 import Logo from './graphics/Logo';
@@ -8,17 +7,7 @@ import Paper from '../Icons/paper.svg';
 
 import styles from './Leadspace.module.scss';
 
-type LeadspaceProps = {
-  onJoinCommunity: () => void;
-  onCheckLatestModel: () => void;
-  onReadPaper: () => void;
-};
-
-const Leadspace: FC<LeadspaceProps> = ({
-  onJoinCommunity,
-  onCheckLatestModel,
-  onReadPaper,
-}) => (
+const Leadspace = () => (
   <section className={styles.pane}>
     <Grid>
       <Column
@@ -32,18 +21,23 @@ const Leadspace: FC<LeadspaceProps> = ({
         <p className={styles.content__subhead}>
           A new community-based approach to build truly open-source LLMs
         </p>
-        <Button className={styles.action} onClick={onJoinCommunity}>
+        <Button href="https://github.com/instructlab" className={styles.action}>
           <GitHub className={styles.icon} />
-          <label>Join the community</label> <ArrowRight />
+          <span>Join the community</span> <ArrowRight />
         </Button>
-        <Button className={styles.action} onClick={onCheckLatestModel}>
+        <Button
+          href="https://huggingface.co/instructlab"
+          className={styles.action}
+        >
           <HuggingFace className={styles.icon} />
-          <label>Check out the latest model</label>
-          <ArrowRight />
+          <span>Check out the latest model</span> <ArrowRight />
         </Button>
-        <Button className={styles.action} onClick={onReadPaper}>
+        <Button
+          href="https://arxiv.org/abs/2403.01081"
+          className={styles.action}
+        >
           <Paper className={styles.icon} />
-          <label>Read the paper</label> <ArrowRight />
+          <span>Read the paper</span> <ArrowRight />
         </Button>
       </Column>
       <Column

--- a/src/components/StartExperimenting/StartExperimenting.module.scss
+++ b/src/components/StartExperimenting/StartExperimenting.module.scss
@@ -69,7 +69,7 @@
           margin-top: 48px;
         }
 
-        label {
+        span {
           flex: 1;
         }
 

--- a/src/components/StartExperimenting/StartExperimenting.tsx
+++ b/src/components/StartExperimenting/StartExperimenting.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { FC } from 'react';
 import { Button, Column, Grid } from '@carbon/react';
 import { ArrowRight } from '@carbon/icons-react';
 import GitHub from '../Icons/github.svg';
@@ -36,11 +35,7 @@ export const headerAnimations = {
   },
 };
 
-type StartExperimentingProps = {
-  onCtaClicked: () => void;
-};
-
-const StartExperimenting: FC<StartExperimentingProps> = ({ onCtaClicked }) => (
+const StartExperimenting = () => (
   <section className={styles.pane}>
     <Grid className={styles.grid}>
       <Column
@@ -67,9 +62,9 @@ const StartExperimenting: FC<StartExperimentingProps> = ({ onCtaClicked }) => (
           outputs, and then contribute your skills recipes and knowledge sources
           back to the community.
         </p>
-        <Button className={styles.action} onClick={onCtaClicked}>
+        <Button href="https://github.com/instructlab" className={styles.action}>
           <GitHub className={styles.icon} />
-          <label>Join the community</label> <ArrowRight />
+          <span>Join the community</span> <ArrowRight />
         </Button>
       </Column>
     </Grid>
@@ -80,11 +75,12 @@ const StartExperimenting: FC<StartExperimentingProps> = ({ onCtaClicked }) => (
             <p>&copy; InstructLab</p>
 
             <p>
-              <a href="https://github.com/instructlab/">GitHub</a>&nbsp;|&nbsp;
+              <a href="https://github.com/instructlab/">GitHub</a>
+              {' | '}
               <a href="https://github.com/instructlab/community/blob/main/Collaboration.md">
                 Collaborate
               </a>
-              &nbsp;|&nbsp;
+              {' | '}
               <a href="https://github.com/instructlab/community/blob/main/CODE_OF_CONDUCT.md">
                 Code of Conduct
               </a>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,7 +1,6 @@
 import Head from 'next/head';
 import PageShell from '../components/PageShell/PageShell';
 import Leadspace from '../components/Leadspace/Leadspace';
-import { useCallback } from 'react';
 import ReleaseCycle from '../components/ReleaseCycle/ReleaseCycle';
 import HowItWorks from '../components/HowItWorks/Slideshow';
 import StartExperimenting from '../components/StartExperimenting/StartExperimenting';
@@ -10,22 +9,6 @@ import Taxonomy from '../components/Taxonomy/Taxonomy';
 import styles from '../styles/main.module.scss';
 
 export default function Home() {
-  const handleJoinCommunity = useCallback(() => {
-    window.location.href = 'https://github.com/instructlab';
-  }, []);
-
-  const handleCheckLatestModel = useCallback(() => {
-    window.location.href = 'https://huggingface.co/instructlab';
-  }, []);
-
-  const handleStartExperimentingCtaClick = useCallback(() => {
-    window.location.href = 'https://github.com/instructlab';
-  }, []);
-
-  const handleReadPaper = useCallback(() => {
-    window.location.href = 'https://arxiv.org/abs/2403.01081';
-  }, []);
-
   return (
     <>
       <Head>
@@ -39,15 +22,11 @@ export default function Home() {
       </Head>
       <main className={styles.main}>
         <PageShell>
-          <Leadspace
-            onJoinCommunity={handleJoinCommunity}
-            onCheckLatestModel={handleCheckLatestModel}
-            onReadPaper={handleReadPaper}
-          />
+          <Leadspace />
           <ReleaseCycle />
           <HowItWorks />
           <Taxonomy />
-          <StartExperimenting onCtaClicked={handleStartExperimentingCtaClick} />
+          <StartExperimenting />
         </PageShell>
       </main>
     </>


### PR DESCRIPTION
Hi, this improves the a11y of the website/homepage a bit:

1. Use good old anchors in `Leadspace` and `StartExperimenting' and remove the callbacks that just redirect the page. This allows users to use ctrl+click and cmd+click, and it might also be better for screen readers (also if they will work with buttons...).
2. The button instead of the div allows users to navigate in the `Slideshow` with the keyboard (tab and enter or space).
