### PR TITLE
add redirect link for discord

### DIFF
--- a/src/pages/discord.tsx
+++ b/src/pages/discord.tsx
@@ -1,0 +1,12 @@
+import { useEffect } from 'react';
+import { useRouter } from 'next/router';
+
+export default function DiscordRedirectPage() {
+  const router = useRouter();
+
+  useEffect(() => {
+    router.replace('https://discord.gg/Fa6tRapUZ2');
+  }, [router]);
+
+  return null;
+}


### PR DESCRIPTION
This PR adds a top-level route as `/discord` so that we can point users to `https://instructlab.ai/discord` and they would be automatically redirected there.


Signed-off-by: Oleg S <97077423+RobotSail@users.noreply.github.com>
